### PR TITLE
Leave function links undecorated until hover

### DIFF
--- a/lib/docurium.rb
+++ b/lib/docurium.rb
@@ -92,7 +92,7 @@ class Docurium
                     @data[:functions][f][:examples] ||= {}
                     @data[:functions][f][:examples][file] ||= []
                     @data[:functions][f][:examples][file] << rel_path + '#' + name
-                    "<a name=\"#{name}\" href=\"../../##{version}/group/#{fdata[:group]}/#{f}\">#{f}</a>#{extra}"
+                    "<a name=\"#{name}\" class=\"fnlink\" href=\"../../##{version}/group/#{fdata[:group]}/#{f}\">#{f}</a>#{extra}"
                   end
                 end
 

--- a/lib/docurium/layout.mustache
+++ b/lib/docurium/layout.mustache
@@ -4,6 +4,10 @@
   <meta http-equiv="content-type" content="text/html;charset=utf-8">
   <title>{{ title }}</title>
   <link rel="stylesheet" href="http://jashkenas.github.com/docco/resources/docco.css">
+  <style type="text/css">
+    a.fnlink {text-decoration: none}
+    a.fnlink:hover {text-decoration: underline}
+  </style>
 </head>
 <body>
 <div id='container'>


### PR DESCRIPTION
This what I meant in issue #2. WE override the (otherwise excellent) stylesheet and only underline the links on hover. This makes the code much more readable IMHO, as you can see the actual function name.
