### PR TITLE
Allow functions with just two namespace levels

### DIFF
--- a/lib/docurium.rb
+++ b/lib/docurium.rb
@@ -374,9 +374,9 @@ class Docurium
         k = key
       end
       group, rest = k.split('_', 2)
-      next if group.empty?
-      if !rest
-        group = value[:file].gsub('.h', '').gsub('/', '_')
+      if group.empty?
+        puts "empty group for function #{key}"
+        next
       end
       data[:functions][key][:group] = group
       func[group] ||= []

--- a/test/docurium_test.rb
+++ b/test/docurium_test.rb
@@ -40,7 +40,7 @@ END
   def test_can_parse_headers
     keys = @data.keys.map { |k| k.to_s }.sort
     assert_equal ['callbacks', 'files', 'functions', 'globals', 'groups', 'prefix', 'types'], keys
-    assert_equal 154, @data[:functions].size
+    assert_equal 155, @data[:functions].size
   end
 
   def test_can_extract_enum_from_define
@@ -175,8 +175,8 @@ END
   end
 
   def test_can_group_functions
-    groups = %w(blob commit index lasterror object odb oid reference repository revwalk signature strerror tag tree treebuilder work)
-    assert_equal groups, @data[:groups].map {|g| g[0]}
+    groups = %w(blob cherrypick commit index lasterror object odb oid reference repository revwalk signature strerror tag tree treebuilder work)
+    assert_equal groups, @data[:groups].map {|g| g[0]}.sort
     group, funcs = @data[:groups].first
     assert_equal 'blob', group
     assert_equal 6, funcs.size

--- a/test/docurium_test.rb
+++ b/test/docurium_test.rb
@@ -175,7 +175,8 @@ END
   end
 
   def test_can_group_functions
-    assert_equal 15, @data[:groups].size
+    groups = %w(blob commit index lasterror object odb oid reference repository revwalk signature strerror tag tree treebuilder work)
+    assert_equal groups, @data[:groups].map {|g| g[0]}
     group, funcs = @data[:groups].first
     assert_equal 'blob', group
     assert_equal 6, funcs.size

--- a/test/fixtures/git2/cherrypick.h
+++ b/test/fixtures/git2/cherrypick.h
@@ -1,0 +1,17 @@
+#ifndef INCLUDE_git_blob_h__
+#define INCLUDE_git_blob_h__
+
+#include "common.h"
+#include "types.h"
+
+GIT_BEGIN_DECL
+
+/**
+ * Perform a cherry-pick
+ *
+ * @param input dummy input
+ * @returns the usual
+ */
+GIT_EXTERN(int) git_cherrypick(char *input);
+
+GIT_END_DECL


### PR DESCRIPTION
Functions like `git_cherrypick` should be in the `cherrypick` group even though it doesn't have a third level of namespacing.