### PR TITLE
Warn on undocumented globals

### DIFF
--- a/bin/cm
+++ b/bin/cm
@@ -20,6 +20,15 @@ command :doc do |c|
   end
 end
 
+desc 'Check documentation for warnings'
+long_desc 'Check a project\'s documentation for issues'
+command :check do |c|
+  c.action do |global_options,options,args|
+    file = args.first
+    Docurium::CLI.check(file, options)
+  end
+end
+
 desc 'Generate Docurium config file template'
 long_desc 'Generate Docurium config file template'
 command :gen do |c|

--- a/lib/docurium.rb
+++ b/lib/docurium.rb
@@ -322,6 +322,15 @@ class Docurium
         under_type = type[:type] if type_id == :types
 
         warnings << Warning::MissingDocumentation.new(under_type, ident) if type[:description].empty?
+
+        case type[:type]
+        when :struct
+          if type[:fields]
+            type[:fields].each do |field|
+              warnings << Warning::MissingDocumentation.new(:field, "#{ident}.#{field[:name]}") if field[:comments].empty?
+            end
+          end
+        end
       end
     end
 

--- a/lib/docurium/cli.rb
+++ b/lib/docurium/cli.rb
@@ -6,6 +6,11 @@ class Docurium
       doc.generate_docs(options)
     end
 
+    def self.check(idir, options)
+      doc = Docurium.new(idir)
+      doc.check_warnings(options)
+    end
+
     def self.gen(file)
 
 temp = <<-TEMPLATE


### PR DESCRIPTION
(extracted from #26, based on #34)

This adds a warning on missing documentation comments on globals.