### PR TITLE
Add missing #endif guard

### DIFF
--- a/test/fixtures/git2/cherrypick.h
+++ b/test/fixtures/git2/cherrypick.h
@@ -15,3 +15,5 @@ GIT_BEGIN_DECL
 GIT_EXTERN(int) git_cherrypick(char *input);
 
 GIT_END_DECL
+
+#endif


### PR DESCRIPTION
It seems the missing `#endif` guard displeases Apple's clang.