### PR TITLE
Initialise the HTML renderer options

### DIFF
--- a/lib/docurium.rb
+++ b/lib/docurium.rb
@@ -421,7 +421,7 @@ class Docurium
 
     file_map = {}
 
-    md = Redcarpet::Markdown.new Redcarpet::Render::HTML, :no_intra_emphasis => true
+    md = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new({}), :no_intra_emphasis => true)
     recs.each do |r|
 
       # initialize filemap for this file


### PR DESCRIPTION
This avoids the warnings of a missing options instance variable. Presumably this
is because we passed in the class instead of a new instance of it.

This should be a less intrusive and workaroundy version of the silencing in #40 