### PR TITLE
Switch to parallel gem

### DIFF
--- a/docurium.gemspec
+++ b/docurium.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rugged", "~>0.21"
   s.add_dependency "redcarpet", "~>3.0"
   s.add_dependency "ffi-clang", "~> 0.5"
+  s.add_dependency "parallel", "~> 1.17.0"
   s.add_development_dependency "rake", "~> 12"
   s.add_development_dependency "minitest", "~> 5.11"
 

--- a/lib/docurium.rb
+++ b/lib/docurium.rb
@@ -288,7 +288,7 @@ class Docurium
 
     def message
       msg = self._message
-      msg.shift % msg.map {|a| self.send(a).to_s } if msg.kind_of?(Array)
+      msg.kind_of?(Array) ? msg.shift % msg.map {|a| self.send(a).to_s } : msg
     end
   end
 


### PR DESCRIPTION
#26 originally removed all traces of parallelism in favor of less file-descriptor contention. It turns out Ruby has gems, and some of those provide ready-made, easy-to-use wrappers for parallel processing.

Use https://github.com/grosser/parallel instead of rolling our own, or removing parallelization altogether.

(Note that this is based on #39, for historic reasons. I can rebase that on top of master if it makes it easier to go in).