### PR TITLE
Add debugging helpers

### DIFF
--- a/bin/cm
+++ b/bin/cm
@@ -15,6 +15,9 @@ long_desc 'Generate HTML docs from a Docurium config file'
 command :doc do |c|
   c.flag :for, :desc => "The version to generate", :multiple => true
   c.switch [:n, "dry-run"], :desc => "Dry-run"
+  c.flag "debug-file", :desc => "Enable debug output for header", :multiple => true
+  c.flag "debug-function", :desc => "Show debug output when processing function", :multiple => true
+  c.flag "debug-type", :desc => "Show debug output when processing type", :multiple => true
   c.action do |global_options,options,args|
     file = args.first
     Docurium::CLI.doc(file, options)

--- a/bin/cm
+++ b/bin/cm
@@ -15,6 +15,7 @@ long_desc 'Generate HTML docs from a Docurium config file'
 command :doc do |c|
   c.flag :for, :desc => "The version to generate", :multiple => true
   c.switch [:n, "dry-run"], :desc => "Dry-run"
+  c.switch [:d, "debug"], :desc => "Enable debug log"
   c.flag "debug-file", :desc => "Enable debug output for header", :multiple => true
   c.flag "debug-function", :desc => "Show debug output when processing function", :multiple => true
   c.flag "debug-type", :desc => "Show debug output when processing type", :multiple => true

--- a/bin/cm
+++ b/bin/cm
@@ -14,6 +14,7 @@ desc 'Generate HTML documentation'
 long_desc 'Generate HTML docs from a Docurium config file'
 command :doc do |c|
   c.flag :for, :desc => "The version to generate", :multiple => true
+  c.switch [:n, "dry-run"], :desc => "Dry-run"
   c.action do |global_options,options,args|
     file = args.first
     Docurium::CLI.doc(file, options)

--- a/lib/docurium.rb
+++ b/lib/docurium.rb
@@ -179,7 +179,7 @@ class Docurium
       # There's still some work we need to do serially
       tally_sigs!(version, data)
       force_utf8(data)
-      sha = @repo.write(data.to_json, :blob)
+      sha = @repo.write(data.to_json, :blob) unless dry_run?
 
       print "Generating documentation [#{i}/#{nversions}]\r"
 
@@ -188,9 +188,11 @@ class Docurium
         head_data = data
       end
 
-      output_index.add(:path => "#{version}.json", :oid => sha, :mode => 0100644)
-      examples.each do |path, id|
-        output_index.add(:path => path, :oid => id, :mode => 0100644)
+      unless dry_run?
+        output_index.add(:path => "#{version}.json", :oid => sha, :mode => 0100644)
+        examples.each do |path, id|
+          output_index.add(:path => path, :oid => id, :mode => 0100644)
+        end
       end
 
       if head_data
@@ -199,6 +201,8 @@ class Docurium
       end
 
     end
+
+    return if dry_run?
 
     # We tally the signatures in the order they finished, which is
     # arbitrary due to the concurrency, so we need to sort them once
@@ -561,5 +565,9 @@ class Docurium
 
   def out(text)
     puts text
+  end
+
+  def dry_run?
+    @cli_options[:dry_run]
   end
 end

--- a/lib/docurium.rb
+++ b/lib/docurium.rb
@@ -4,6 +4,7 @@ require 'version_sorter'
 require 'rocco'
 require 'docurium/version'
 require 'docurium/layout'
+require 'docurium/debug'
 require 'libdetect'
 require 'docurium/docparser'
 require 'pp'
@@ -299,7 +300,7 @@ class Docurium
     data = init_data(version)
     DocParser.with_files(files, :prefix => version) do |parser|
       headers.each do |header|
-        records = parser.parse_file(header)
+        records = parser.parse_file(header, debug: interesting?(:file, header))
         update_globals!(data, records)
       end
     end
@@ -374,16 +375,20 @@ class Docurium
   def group_functions!(data)
     func = {}
     data[:functions].each_pair do |key, value|
+      debug_set interesting?(:function, key)
+      debug "grouping #{key}: #{value}"
       if @options['prefix']
         k = key.gsub(@options['prefix'], '')
       else
         k = key
       end
       group, rest = k.split('_', 2)
+      debug "grouped: k: #{k}, group: #{group}, rest: #{rest}"
       if group.empty?
         puts "empty group for function #{key}"
         next
       end
+      debug "grouped: k: #{k}, group: #{group}, rest: #{rest}"
       data[:functions][key][:group] = group
       func[group] ||= []
       func[group] << key
@@ -428,6 +433,25 @@ class Docurium
 
     md = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new({}), :no_intra_emphasis => true)
     recs.each do |r|
+
+      types = %w(function file type).map(&:to_sym)
+      dbg = false
+      types.each do |t|
+        dbg ||= if r[:type] == t and interesting?(t, r[:name])
+          true
+        elsif t == :file and interesting?(:file, r[:file])
+          true
+        elsif [:struct, :enum].include?(r[:type]) and interesting?(:type, r[:name])
+          true
+        else
+          false
+        end
+      end
+
+      debug_set dbg
+
+      debug "processing record: #{r}"
+      debug
 
       # initialize filemap for this file
       file_map[r[:file]] ||= {
@@ -536,6 +560,10 @@ class Docurium
         # Anything else we want to record?
       end
 
+      debug "processed record: #{r}"
+      debug
+
+      debug_restore
     end
 
     data[:files] << file_map.values[0]
@@ -569,5 +597,9 @@ class Docurium
 
   def dry_run?
     @cli_options[:dry_run]
+  end
+
+  def interesting?(type, what)
+    (@cli_options["debug-#{type}"] || []).include?(what)
   end
 end

--- a/lib/docurium.rb
+++ b/lib/docurium.rb
@@ -600,6 +600,6 @@ class Docurium
   end
 
   def interesting?(type, what)
-    (@cli_options["debug-#{type}"] || []).include?(what)
+    @cli_options['debug'] || (@cli_options["debug-#{type}"] || []).include?(what)
   end
 end

--- a/lib/docurium.rb
+++ b/lib/docurium.rb
@@ -19,11 +19,12 @@ Rocco::Markdown = RedcarpetCompat
 class Docurium
   attr_accessor :branch, :output_dir, :data
 
-  def initialize(config_file, repo = nil)
+  def initialize(config_file, cli_options = {}, repo = nil)
     raise "You need to specify a config file" if !config_file
     raise "You need to specify a valid config file" if !valid_config(config_file)
     @sigs = {}
     @repo = repo || Rugged::Repository.discover(config_file)
+    @cli_options = cli_options
   end
 
   def init_data(version = 'HEAD')
@@ -119,14 +120,14 @@ class Docurium
     data
   end
 
-  def generate_docs(options)
+  def generate_docs
     output_index = Rugged::Index.new
     write_site(output_index)
     @tf = File.expand_path(File.join(File.dirname(__FILE__), 'docurium', 'layout.mustache'))
     versions = get_versions
     versions << 'HEAD'
     # If the user specified versions, validate them and overwrite
-    if !(vers = options[:for]).empty?
+    if !(vers = @cli_options[:for]).empty?
       vers.each do |v|
         next if versions.include?(v)
         puts "Unknown version #{v}"

--- a/lib/docurium/cli.rb
+++ b/lib/docurium/cli.rb
@@ -2,8 +2,8 @@ class Docurium
   class CLI
 
     def self.doc(idir, options)
-      doc = Docurium.new(idir)
-      doc.generate_docs(options)
+      doc = Docurium.new(idir, options)
+      doc.generate_docs
     end
 
     def self.gen(file)

--- a/lib/docurium/debug.rb
+++ b/lib/docurium/debug.rb
@@ -1,0 +1,41 @@
+$debug_stack = [false]
+
+def debug_enabled
+  $debug_stack[-1]
+end
+
+def debug(str = nil)
+  puts str if debug_enabled
+end
+
+def debug_enable
+  $debug_stack.push true
+end
+
+def debug_silence
+  $debug_stack.push false
+end
+
+def debug_set val
+  $debug_stack.push val
+end
+
+def debug_pass
+  $debug_stack.push debug_enabled
+end
+
+def debug_restore
+  $debug_stack.pop
+end
+
+def with_debug(&block)
+  debug_enable
+  block.call
+  debug_restore
+end
+
+def without_debug(&block)
+  debug_silence
+  block.call
+  debug_restore
+end

--- a/test/docurium_test.rb
+++ b/test/docurium_test.rb
@@ -20,7 +20,7 @@ class DocuriumTest < Minitest::Test
     end
 
     @path = File.dirname(__FILE__) + '/fixtures/git2/api.docurium'
-    @doc = Docurium.new(@path, @repo)
+    @doc = Docurium.new(@path, {}, @repo)
     @data = @doc.parse_headers(index, 'HEAD')
   end
 


### PR DESCRIPTION
This adds a quick debugging interface, so it's easier to grasp what's actually going wrong while processing cursors. Arguably, my other PRs that need arguments only depend on https://github.com/libgit2/docurium/commit/a17c1512a6977a889a92779c8830b560f09f8762, so if the debugging is too much, I can fold. But to be frank, it has been a great help already in pinpointing types that fail to document properly.

Extracted from #26, depends on #39.