### PR TITLE
Use clang's include paths when parsing the translation units

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
     packages:
       - libclang-6.0-dev
       - llvm-6.0
+      - clang-6.0
 rvm:
  - ruby-2.4
  - ruby-2.5

--- a/lib/docurium/docparser.rb
+++ b/lib/docurium/docparser.rb
@@ -26,7 +26,7 @@ class Docurium
 
       # Override the path we want to filter by
       filename = File.join(tmpdir, orig_filename)
-      tu = Index.new.parse_translation_unit(filename, ["-DDOCURIUM=1"], unsaved, {:detailed_preprocessing_record => 1})
+      tu = Index.new(true, true).parse_translation_unit(filename, ["-DDOCURIUM=1"], unsaved, {:detailed_preprocessing_record => 1})
 
       FileUtils.remove_entry(tmpdir)
 

--- a/lib/docurium/docparser.rb
+++ b/lib/docurium/docparser.rb
@@ -10,9 +10,9 @@ class Docurium
     # included in our default search path, so as a workaround we execute clang
     # in verbose mode and grab its include paths from the output.
     def find_clang_includes
-      clang = ENV["CLANG"] || "clang"
+      bindir = `#{ENV["LLVM_CONFIG"]} --bindir`.strip
+      clang = "#{bindir}/clang"
       output, _status = Open3.capture2e("#{clang} -v -x c -", :stdin_data => "")
-      #output = `#{clang} -v -x c - </dev/null`
       includes = []
       output.each_line do |line|
         if line =~ %r{^\s+/.*lib/clang.*/include}

--- a/lib/docurium/docparser.rb
+++ b/lib/docurium/docparser.rb
@@ -45,7 +45,7 @@ class Docurium
         UnsavedFile.new(full_path, contents)
       end
 
-      includes = find_clang_includes
+      includes = find_clang_includes + [tmpdir]
 
       # Override the path we want to filter by
       filename = File.join(tmpdir, orig_filename)

--- a/lib/docurium/docparser.rb
+++ b/lib/docurium/docparser.rb
@@ -10,17 +10,20 @@ class Docurium
     # included in our default search path, so as a workaround we execute clang
     # in verbose mode and grab its include paths from the output.
     def find_clang_includes
-      bindir = `#{ENV["LLVM_CONFIG"]} --bindir`.strip
-      clang = "#{bindir}/clang"
-      output, _status = Open3.capture2e("#{clang} -v -x c -", :stdin_data => "")
-      includes = []
-      output.each_line do |line|
-        if line =~ %r{^\s+/.*lib/clang.*/include}
-          includes << line.strip
-        end
-      end
+      @includes ||=
+        begin
+          bindir = `#{ENV["LLVM_CONFIG"]} --bindir`.strip
+          clang = "#{bindir}/clang"
+          output, _status = Open3.capture2e("#{clang} -v -x c -", :stdin_data => "")
+          includes = []
+          output.each_line do |line|
+            if line =~ %r{^\s+/.*lib/clang.*/include}
+              includes << line.strip
+            end
+          end
 
-      includes
+          includes
+        end
     end
 
     # Entry point for this parser

--- a/test/fixtures/git2/common.h
+++ b/test/fixtures/git2/common.h
@@ -28,6 +28,7 @@
 #include "thread-utils.h"
 #include <time.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 # define GIT_BEGIN_DECL  extern "C" {

--- a/test/fixtures/git2/common.h
+++ b/test/fixtures/git2/common.h
@@ -40,12 +40,6 @@
 # define GIT_END_DECL    /* empty */
 #endif
 
-/*
- * libclang won't consider anything with size_t to have comments unless we use
- * this hack.
- */
-typedef size_t size_t;
-
 /** Declare a public function exported for application use. */
 #ifdef __GNUC__
 # define GIT_EXTERN(type) extern \


### PR DESCRIPTION
For quite a while we've had the issue that some type definitions were missing, most notably `size_t` when generating documentation for libgit2. We "solved" that by defining it ourselves when `DOCURIUM` is defined. This is clearly a terrible hack but we did not know what was happening.

Then in #39 we got errors about not finding `stddef.h`. Further investigation revealed that this was because that PR included a change to ask the library to print out errors.

It turns out that by default we do not include the directory in which clang stores its headers, which means we've been missing some necessary ones for quite some time now.

This PR queries clang for its include file by parsing its verbose output (inspiration from drothlis/clang-ctags#7) and passing it as an include path. We also remove `-DDOCURIUM=1` as it should no longer be necessary.