### PR TITLE
Link more types in the documentation

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -212,6 +212,15 @@
       <a href="<%= fun.url %>"><%= fun.name %></a>.
       <% } %> <!-- if we have 'needs' -->
 
+      <% if (fields.length > 0) { %>
+      <h3>Field in</h3>
+      <% _.each(_.initial(fields), function(fun) { %>
+        <a href="<%= fun.url %>"><%= fun.name %></a>,
+      <% }) %><!-- loop over each 'field' -->
+      <% var fun = _.last(fields) %>
+      <a href="<%= fun.url %>"><%= fun.name %></a>
+      <% } %><!-- if we have 'fields' -->
+
       <div class="fileLink">
         Defined in:
         <a href="<%= fileLink.url %>"><%= fileLink.name %></a>

--- a/site/js/docurium.js
+++ b/site/js/docurium.js
@@ -600,18 +600,17 @@ $(function() {
       types = this.get('data')['types']
       var version = this.get('version')
 
-      for(var i=0; i<types.length; i++) {
-        type = types[i]
-        typeName = type[0]
-        typeData = type[1]
-        re = new RegExp(typeName + '\\s', 'gi');
+      _.each(types, function(type) {
+        var typeName = type[0];
+        var typeData = type[1];
+        var re = new RegExp(typeName + '\\s', 'gi');
         var link = $('<a>').attr('href', '#' + typeLink(typeName, version)).append(typeName)[0]
         text = text.replace(re, link.outerHTML + ' ')
-      }
+      });
 
       var callbacks = this.get('data')['callbacks']
       _.each(callbacks, function(cb, typeName) {
-        re = new RegExp(typeName + '$', 'gi');
+        var re = new RegExp(typeName + '$', 'gi');
         var link = $('<a>').attr('href', '#' + functionLink('callback', typeName, version)).append(typeName)[0]
         text = text.replace(re, link.outerHTML + ' ')
       });

--- a/site/js/docurium.js
+++ b/site/js/docurium.js
@@ -352,14 +352,20 @@ $(function() {
       var tname = tdata[0]
       var data = tdata[1]
 
-      var toPair = function(fun) {
+      var toFuncPair = function(fun) {
         var gname = this.groupOf(fun)
         var url = '#' + functionLink(gname, fun, version)
         return {name: fun, url: url}
       }
 
-      var returns = _.map(data.used.returns, toPair, docurium)
-      var needs = _.map(data.used.needs, toPair, docurium)
+      var toTypePair = function(type) {
+        var url = '#' + typeLink(type, version)
+        return {name: type, url: url}
+      }
+
+      var returns = _.map(data.used.returns, toFuncPair, docurium)
+      var needs = _.map(data.used.needs, toFuncPair, docurium)
+      var fields = _.map(data.used.fields, toTypePair, docurium)
       var fileLink = {name: data.file, url: docurium.github_file(data.file, data.line, data.lineto)}
 
       // Hot link our field types
@@ -367,7 +373,7 @@ $(function() {
         return {type: this.hotLink(field.type), name: field.name, comments: field.comments}
       }, docurium)
 
-      this.set('data', {tname: tname, data: data, returns: returns, needs: needs, fileLink: fileLink})
+      this.set('data', {tname: tname, data: data, returns: returns, needs: needs, fields: fields, fileLink: fileLink})
     }
   })
 

--- a/site/js/docurium.js
+++ b/site/js/docurium.js
@@ -603,7 +603,7 @@ $(function() {
       _.each(types, function(type) {
         var typeName = type[0];
         var typeData = type[1];
-        var re = new RegExp(typeName + '\\s', 'gi');
+        var re = new RegExp('\\b' + typeName + '\\b', 'gi');
         var link = $('<a>').attr('href', '#' + typeLink(typeName, version)).append(typeName)[0]
         text = text.replace(re, link.outerHTML + ' ')
       });

--- a/test/docurium_test.rb
+++ b/test/docurium_test.rb
@@ -52,7 +52,7 @@ class DocuriumTest < Minitest::Test
   end
 
   def test_can_find_type_usage
-    oid = @data[:types].assoc('git_oid')
+    oid = @data[:types].find {|a| a[0] == 'git_oid' }
     oid_returns = [
       "git_commit_id",
       "git_commit_parent_oid",


### PR DESCRIPTION
This PR improves type hotlinking by making sure we look for type usage in struct fields, as well as a quick fix for the regex that JS uses to hotlink types. This was triggered by missing `git_oid` links in the current libgit2 API.