### PR TITLE
Add clean exit if no git user configuration is set

### DIFF
--- a/lib/docurium.rb
+++ b/lib/docurium.rb
@@ -162,6 +162,11 @@ class Docurium
       versions = vers
     end
 
+    if (@repo.config['user.name'].nil? || @repo.config['user.email'].nil?)
+      puts "ERROR: 'user.name' or 'user.email' is not configured. Docurium will not be able to commit the documentation"
+      exit(false)
+    end
+
     process_project(versions) do |i, version, result|
       data, examples = result
       sha = @repo.write(data.to_json, :blob)


### PR DESCRIPTION
If the 'user.name' and 'user.email' are not configured, the commit of
the generated documentation fail.
In this case, the options ['author'] and ['committer'] argument of the
Rugged::Commit.create(..), contain a nil content but a string was
expected.