### PR TITLE
Update gems, let CI work with ruby 3

### DIFF
--- a/docurium.gemspec
+++ b/docurium.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "redcarpet", "~>3.0"
   s.add_dependency "ffi-clang", "~> 0.5"
   s.add_dependency "parallel", "~> 1.20"
-  s.add_development_dependency "rake", "~> 12"
+  s.add_development_dependency "rake", "~> 13"
   s.add_development_dependency "minitest", "~> 5.11"
 
   s.files         = `git ls-files`.split("\n")

--- a/docurium.gemspec
+++ b/docurium.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.add_dependency "mustache", "~> 1.1"
   s.add_dependency "rocco", "~>0.8"
   s.add_dependency "gli", "~>2.5"
-  s.add_dependency "rugged", "~>0.21"
+  s.add_dependency "rugged", "~>1.1"
   s.add_dependency "redcarpet", "~>3.0"
   s.add_dependency "ffi-clang", "~> 0.5"
-  s.add_dependency "parallel", "~> 1.17.0"
+  s.add_dependency "parallel", "~> 1.20"
   s.add_development_dependency "rake", "~> 12"
   s.add_development_dependency "minitest", "~> 5.11"
 


### PR DESCRIPTION
Some updates to the gems we use. Of particular interest is the fact that the `rubysl` stuff around rubinious makes bundle try to install it and as it requires ruby 2, we cannot fulfill that on 3 and thus fail. This should let the Travis job that tests against ruby head work again.